### PR TITLE
Update node-sass to 4.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "cordova": "^6.3.1",
     "del": "^2.2.2",
     "ncp": "^2.0.0",
-    "node-sass": "^3.10.1",
+    "node-sass": "^4.3.0",
     "requirejs": "^2.3.2",
     "resolve": "^1.1.7",
     "ripple-emulator": "^0.9.36",
@@ -45,6 +45,6 @@
     "oracle",
     "oracle-jet",
     "jet",
-    "javscript extension toolkit"
+    "javascript extension toolkit"
   ]
 }


### PR DESCRIPTION
I had some issues running `npm run dev` both on my OSX and Windows machines because of node-sass not supporting my nodejs version. I noticed that node-sass is still on version 3.* so I updated to 4.3.0, which fixed the issue for me.

I also fixed a small typo in the keywords ;)